### PR TITLE
main: Fix build errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	release, _, _ := client.Repositories.GetLatestRelease(repoOwner, repo)
 
-	var tags []github.RepositoryTag
+	var tags []*github.RepositoryTag
 	var tagsOpts github.ListOptions
 
 	for {
@@ -83,7 +83,7 @@ func main() {
 
 	fmt.Fprintf(f, "Changes since last release\n\n")
 
-	var prs []github.PullRequest
+	var prs []*github.PullRequest
 
 	prOpts := github.PullRequestListOptions{
 		State: "closed",
@@ -107,10 +107,10 @@ func main() {
 
 	prmap := make(map[int]github.PullRequest)
 	for _, pr := range prs {
-		prmap[*pr.Number] = pr
+		prmap[*pr.Number] = *pr
 	}
 
-	var events []github.IssueEvent
+	var events []*github.IssueEvent
 	var eventOpts github.ListOptions
 
 	for {
@@ -128,7 +128,7 @@ func main() {
 		eventOpts.Page = resp.NextPage
 	}
 
-	eventsmap := make(map[string][]github.IssueEvent)
+	eventsmap := make(map[string][]*github.IssueEvent)
 
 	for _, e := range events {
 		key := *e.Event
@@ -170,7 +170,7 @@ func main() {
 		Until: rc,
 	}
 
-	var commits []github.RepositoryCommit
+	var commits []*github.RepositoryCommit
 	for {
 		c, resp, err := client.Repositories.ListCommits(repoOwner, repo, &copts)
 		if err != nil {


### PR DESCRIPTION
We were getting the following build errors:

./main.go:60: cannot use t (type []*github.RepositoryTag) as type []github.RepositoryTag in append
./main.go:99: cannot use pr (type []*github.PullRequest) as type []github.PullRequest in append
./main.go:122: cannot use e (type []*github.IssueEvent) as type []github.IssueEvent in append
./main.go:180: cannot use c (type []*github.RepositoryCommit) as type []github.RepositoryCommit in append

We need to append to array of pointers in order to fix them.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>